### PR TITLE
Increase Thumbnail Height Width to larger size

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -16,8 +16,8 @@ $heading-font:    'geo', monospace, 'Open Sans', 'sans-serif';
 
 /* Image Size */
 
-$thumbnail-height: 380px;
-$thumbnail-width: 380px;
+$thumbnail-height: 270px;
+$thumbnail-width: 270px;
 
 /* colors */
 

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -16,8 +16,8 @@ $heading-font:    'geo', monospace, 'Open Sans', 'sans-serif';
 
 /* Image Size */
 
-$thumbnail-height: 150px;
-$thumbnail-width: 150px;
+$thumbnail-height: 380px;
+$thumbnail-width: 380px;
 
 /* colors */
 


### PR DESCRIPTION
**Summary of Changes**
* Increase the max thumbnail height and width from `190px` to `270px`
  * The [figma design ](https://www.figma.com/file/qiktB0mlf24XSzAKn9Qxhc/Mainframe-Wireframe?node-id=13%3A6) showed a thumbnail size of 380px x 380px, but setting the max thumbnail values to these broke us out of the "square shape" which is why I adapted the height and width of the thumbnail
* The end result can be measure by the maximum number of images per row in the collection: before the change, we should seven thumbnails per row, after the change, only four thumbnails are shown